### PR TITLE
Add support for boringssl keylog callback

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -404,12 +404,12 @@ extern "C" {
     pub fn SSL_extension_supported(ext_type: c_uint) -> c_int;
 }
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub type SSL_CTX_keylog_cb_func =
     Option<unsafe extern "C" fn(ssl: *const SSL, line: *const c_char)>;
 
 extern "C" {
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl))]
     pub fn SSL_CTX_set_keylog_callback(ctx: *mut SSL_CTX, cb: SSL_CTX_keylog_cb_func);
 
     #[cfg(any(ossl111, libressl340))]

--- a/openssl/src/ssl/callbacks.rs
+++ b/openssl/src/ssl/callbacks.rs
@@ -11,7 +11,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::slice;
-#[cfg(ossl111)]
+#[cfg(any(ossl102, boringssl))]
 use std::str;
 use std::sync::Arc;
 
@@ -28,7 +28,7 @@ use crate::ssl::{
 use crate::ssl::{ClientHello, SelectCertError};
 #[cfg(ossl111)]
 use crate::ssl::{ClientHelloError, ExtensionContext};
-#[cfg(ossl111)]
+#[cfg(any(ossl102, boringssl))]
 use crate::util::ForeignTypeRefExt;
 #[cfg(ossl111)]
 use crate::x509::X509Ref;
@@ -373,7 +373,7 @@ where
     }
 }
 
-#[cfg(ossl111)]
+#[cfg(any(ossl111, boringssl))]
 pub unsafe extern "C" fn raw_keylog<F>(ssl: *const ffi::SSL, line: *const c_char)
 where
     F: Fn(&SslRef, &str) + 'static + Sync + Send,

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -1831,7 +1831,7 @@ impl SslContextBuilder {
     ///
     /// Requires OpenSSL 1.1.1 or newer.
     #[corresponds(SSL_CTX_set_keylog_callback)]
-    #[cfg(ossl111)]
+    #[cfg(any(ossl111, boringssl))]
     pub fn set_keylog_callback<F>(&mut self, callback: F)
     where
         F: Fn(&SslRef, &str) + 'static + Sync + Send,


### PR DESCRIPTION
This commit adds support to using keylog callback with boringSSL.